### PR TITLE
🐛 Fix pack upload error message feature

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
@@ -30,7 +30,8 @@ public class UploadManager {
         long time = System.currentTimeMillis();
         Logs.log(ChatColor.GREEN, "Automatic upload of the resource pack is enabled, uploading...");
         Bukkit.getScheduler().runTaskAsynchronously(OraxenPlugin.get(), () -> {
-            hostingProvider.uploadPack(resourcePack.getFile());
+            if (!hostingProvider.uploadPack(resourcePack.getFile()))
+                return;
             Logs.log(ChatColor.GREEN, "Resourcepack uploaded on url "
                     + hostingProvider.getPackURL() + " in " + (System.currentTimeMillis() - time) + "ms");
             if ((boolean) Pack.SEND.getValue())

--- a/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/HostingProvider.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/HostingProvider.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 public interface HostingProvider {
 
-    void uploadPack(File resourcePack);
+    boolean uploadPack(File resourcePack);
 
     String getPackURL();
 

--- a/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/TransferDotSh.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/TransferDotSh.java
@@ -15,7 +15,7 @@ public class TransferDotSh implements HostingProvider {
     private String packURL;
 
     @Override
-    public void uploadPack(File resourcePack) {
+    public boolean uploadPack(File resourcePack) {
         String url = "https://transfer.sh/pack.zip";
         String charset = "UTF-8";
         String boundary = Long.toHexString(System.currentTimeMillis()); // Just generate some unique random value.
@@ -27,7 +27,7 @@ public class TransferDotSh implements HostingProvider {
             connection.setRequestMethod("PUT");
         } catch (IOException ignored) {
             Logs.log(ChatColor.RED, "Can't connect to transfer.sh! Resource pack not uploaded!");
-            return;
+            return false;
         }
 
         connection.setDoOutput(true);
@@ -65,9 +65,11 @@ public class TransferDotSh implements HostingProvider {
                 throw new RuntimeException();
             }
 
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (IOException ignored) {
+            Logs.log(ChatColor.RED, "Can't connect to transfer.sh! Resource pack not uploaded!");
+            return false;
         }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
- 🐛 Fix pack upload error message feature not working as expected and add some forgotten stuff at first (remove resource pack url if not uploaded for example)